### PR TITLE
Fix apache commons-math3 version to be compliant with LPE again

### DIFF
--- a/org.aim.parent/pom.xml
+++ b/org.aim.parent/pom.xml
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-math3</artifactId>
-			<version>3.0</version>
+			<version>3.4.1</version>
 		</dependency>
 		<dependency>
 			<groupId>ant</groupId>


### PR DESCRIPTION
Using the same version 3.4.1 as LPE does now to avoid build errors.

Change-Id: I439c11ba10a495efa828d0af249b60198a0b793f
Signed-off-by: Denis Knoepfle <denis.knoepfle@sap.com>